### PR TITLE
Adding the *patch* package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
       curl \
       libapache2-mod-php7.2 \
       mysql-client \
+      patch \
       php7.2 \
       php7.2-cli \
       php7.2-common \


### PR DESCRIPTION
The *patch* command from the *patch* package is needed by
cweagans/composer-patches.

Issue #3