### PR TITLE
Embed env var values into phpunit.xml.dist

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,6 +27,8 @@ fi
 # PHPUnit tests.
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
+# Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
+docker exec -u docker -t drupal sed "s#http://localgov.lndo.site#${SIMPLETEST_BASE_URL}#; s#mysql://database:database@database/database#${SIMPLETEST_DB}#" --in-place /var/www/html/phpunit.xml.dist
 docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))


### PR DESCRIPTION
brianium/paratest [does not pass](https://github.com/paratestphp/paratest/issues/103) environment variables to PHPUnit.  Our test runs rely on at least two such variables: SIMPLETEST_BASE_URL and SIMPLETEST_DB.  As work around, we are inserting the values of these two environment variables into the phpunit.xml.dist file.  This way, these environment variables would be honoured.