### PR TITLE
Run tests in parallel with paratests (part 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Create LocalGov Drupal project
+        run: composer create-project --stability dev localgovdrupal/localgov-project html
+
       - name: Start Docker environment
         run: docker-compose up -d
-
-      - name: Create LocalGov Drupal project
-        run: |
-          docker exec -u root -t drupal bash -c "mkdir -p /var/www/html && chown docker:docker /var/www/html"
-          docker exec -u docker -t drupal bash -c "/usr/local/bin/composer create-project --keep-vcs --stability dev localgovdrupal/localgov-project /var/www/html"
 
       - name: Run tests
         run: ./run-tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     apt-get install -y \
       apache2 \
       curl \
+      git \
       libapache2-mod-php7.2 \
       mysql-client \
       patch \
@@ -22,6 +23,7 @@ RUN apt-get update && \
       php7.2-mbstring \
       php7.2-mysql \
       php7.2-opcache \
+      php7.2-sqlite \
       php7.2-xml \
       php7.2-zip \
       php-memcached  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY config/php/docker.ini /etc/php/7.2/conf.d/docker.ini
 RUN ln -s /etc/php/7.2/conf.d/docker.ini /etc/php/7.2/apache2/conf.d/90-docker.ini
 
 # Install Composer,
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=1.10.16
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # LocalGovDrupal Docker container
 
-Container for LocalGovDrupal CI, includes Apache, PHP and Composer.
+Container for LocalGov Drupal CI, includes Apache, PHP and Composer.
 
-## Docker Compose
+## Running tests with Docker Compose
 
-To use with the the included `docker-compose.yml` file, create a LocalGovDrupal
-install in an html directory in the git root, start `docker-compose` and then
-run the tests.
+To use with the the included `docker-compose.yml` file, create a LocalGov Drupal install in an html directory in the git root, start `docker-compose` and then run the tests.
 
 Something like:
 
@@ -17,4 +15,15 @@ docker-compose up -d
 docker exec -u docker -t drupal /usr/local/bin/composer create-project --stability dev localgovdrupal/localgov-project /var/www/html
 ./run-tests.sh
 docker-compose stop
+```
+
+## Building the Docker image
+
+The Docker image lives in [Docker Hub](https://hub.docker.com/repository/docker/localgovdrupal/apache-php). Ask in [Slack](https://localgovdrupal.slack.com/) if you need the permissions to push new images.
+
+Build with:
+
+```bash
+docker build . -t localgovdrupal/apache-php:php7.2
+docker push localgovdrupal/apache-php:php7.2
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,19 +17,6 @@ services:
       - "80:80"
     volumes:
       - ./html:/var/www/html
-    depends_on:
-      - "database"
-
-  database:
-    image: mysql:5.7
-    container_name: database
-    environment:
-      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
-      MYSQL_DATABASE: database
-      MYSQL_USER: database
-      MYSQL_PASSWORD: database
-    ports:
-      - "3306:3306"
 
   chrome:
     image: drupalci/webdriver-chromedriver:production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,26 +10,13 @@ services:
     container_name: drupal
     environment:
       SIMPLETEST_BASE_URL: 'http://drupal'
-      SIMPLETEST_DB: 'mysql://database:database@database/database'
+      SIMPLETEST_DB: 'sqlite://sites/default/files/.ht.sqlite'
       MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chrome:9515"]'
       SYMFONY_DEPRECATIONS_HELPER: weak
     ports:
       - "80:80"
     volumes:
       - ./html:/var/www/html
-    depends_on:
-      - "database"
-
-  database:
-    image: mysql:5.7
-    container_name: database
-    environment:
-      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
-      MYSQL_DATABASE: database
-      MYSQL_USER: database
-      MYSQL_PASSWORD: database
-    ports:
-      - "3306:3306"
 
   chrome:
     image: drupalci/webdriver-chromedriver:production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # LocalGovDrupal CI
 ---
 version: '3'
-    
+
 services:
 
   drupal:
@@ -10,13 +10,26 @@ services:
     container_name: drupal
     environment:
       SIMPLETEST_BASE_URL: 'http://drupal'
-      SIMPLETEST_DB: 'sqlite://sites/default/files/.ht.sqlite'
+      SIMPLETEST_DB: 'mysql://database:database@database/database'
       MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chrome:9515"]'
       SYMFONY_DEPRECATIONS_HELPER: weak
     ports:
       - "80:80"
     volumes:
       - ./html:/var/www/html
+    depends_on:
+      - "database"
+
+  database:
+    image: mysql:5.7
+    container_name: database
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+      MYSQL_DATABASE: database
+      MYSQL_USER: database
+      MYSQL_PASSWORD: database
+    ports:
+      - "3306:3306"
 
   chrome:
     image: drupalci/webdriver-chromedriver:production

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,7 +27,7 @@ fi
 # PHPUnit tests.
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
-docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/phpunit --testdox"
+docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,7 +29,7 @@ echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
 docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost/dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
-docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4"
+docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,8 +28,8 @@ fi
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
-docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost//tmp/test.sqlite#" /var/www/html/phpunit.xml.dist'
-docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
+docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost/dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
+docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4"
 if [ $? -ne 0 ]; then
   ((RESULT++))
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,7 +29,7 @@ echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
 docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost/dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
-docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
+docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1 --order-by=random"
 if [ $? -ne 0 ]; then
   ((RESULT++))
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ fi
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
-docker exec -u docker -t drupal bash -c 'sed "s#http://localgov.lndo.site#${SIMPLETEST_BASE_URL}#; s#mysql://database:database@database/database#${SIMPLETEST_DB}#" --in-place /var/www/html/phpunit.xml.dist'
+docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost//tmp/test.sqlite#" /var/www/html/phpunit.xml.dist'
 docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ fi
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
-docker exec -u docker -t drupal sed "s#http://localgov.lndo.site#${SIMPLETEST_BASE_URL}#; s#mysql://database:database@database/database#${SIMPLETEST_DB}#" --in-place /var/www/html/phpunit.xml.dist
+docker exec -u docker -t drupal bash -c 'sed "s#http://localgov.lndo.site#${SIMPLETEST_BASE_URL}#; s#mysql://database:database@database/database#${SIMPLETEST_DB}#" --in-place /var/www/html/phpunit.xml.dist'
 docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,7 +29,7 @@ echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
 docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost/dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
-docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1 --order-by=random"
+docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,6 +27,8 @@ fi
 # PHPUnit tests.
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
+# Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
+docker exec -u docker -t drupal sed "s#http://localgov.lndo.site#${SIMPLETEST_BASE_URL}#; s#mysql://database:database@database/database#${SIMPLETEST_DB}#" --in-place /var/www/html/phpunit.xml.dist
 docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))


### PR DESCRIPTION
This change runs tests using [brianium/paratest](https://github.com/paratestphp/paratest) which executes a few instances of PHPUnit in parallel.

brianium/paratest [does not pass](https://github.com/paratestphp/paratest/issues/103) environment variables to PHPUnit.  Our test runs rely on at least two such variables: SIMPLETEST_BASE_URL and SIMPLETEST_DB.  As a work around, we are inserting the values of these two environment variables into the phpunit.xml.dist file.  This way, these environment variables would be honoured.

I have added one more line to [Paul's original pull request](https://github.com/localgovdrupal/drupal-container/pull/6) and created this one.  I am happy for that one line to go into the original pull request and **this one be not merged**.

With these changes, test runs are taking about 28 minutes to complete compared to 47 minutes without.  When I [originally](https://github.com/localgovdrupal/localgov_paragraphs/runs/1096904645?check_suite_focus=true) tried paratest alongside an SQLite database, it took about 18 minutes.  So there's room for improvement given that we are still using MySQL and not SQLite during test runs.

The key thing to consider about Paratest is the output format of individual tests.  The output format of Paratest is inferior to PHPUnit's built-in [TestDox format](https://phpunit.readthedocs.io/en/9.3/textui.html#testdox) IMHO.  So there is a trade-off between speed and the readability of the test output.  For this reason only, I am raising this pull request to help make a decision and not to immediately merge with the master branch.

FAO @finnlewis @paulpopus @stephen-cox @andybroomfield 