### PR TITLE
Fix for shared-memory path for SQLite file

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ fi
 echo "Running tests"
 docker exec -t drupal bash -c "mkdir -p /var/www/html/web/sites/simpletest && chmod 777 /var/www/html/web/sites/simpletest"
 # Update PHPUnit's env var declarations; Paratest does not pass these to PHPUnit :(
-docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost/dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
+docker exec -u docker -t drupal bash -c 'sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost//dev/shm/test.sqlite#" /var/www/html/phpunit.xml.dist'
 docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 --verbose=1"
 if [ $? -ne 0 ]; then
   ((RESULT++))


### PR DESCRIPTION
Apparently, we missed a slash character from the SQLite file's path.

Current path: sqlite://localhost/dev/shm/test.sqlite
Proposed path: sqlite://localhost//dev/shm/test.sqlite

@see https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/lib/Drupal/Core/Database/Driver/sqlite/Connection.php#L473
@see https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/tests/Drupal/Tests/Core/Database/Driver/sqlite/ConnectionTest.php#L44

I stumbled up on the above links while trying to [troubleshoot localgov_subsites' test failures](https://github.com/localgovdrupal/localgov_subsites/pull/8#issuecomment-743422935) although this change won't help the localgov_subsites one.

This proposed change has brought down the test run time to [under 16 minutes](https://github.com/localgovdrupal/drupal-container/pull/11/checks) from the previous 25+ minutes.  So not bad.  I am still praying for a sub 10 minute run :)

Another option is to try ```sqlite://localhost/:memory:``` leading SQLite to create a temporary database directly [in the memory](https://sqlite.org/inmemorydb.html).  This completely avoids the Operating system's disk API putting SQLite in more direct control.  This is supposed to improve SQLite's performance even further although I haven't noticed any difference in my local development site.  That's why I am sticking with a file system based URL.