### PR TITLE
Use same Chrome Driver settings as Lando

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
   test:
     name: Build and test LocalGov Drupal
     runs-on: ubuntu-latest
-
+    
+    
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: "1.x"
-          - localgov-version: "2.x"
+        localgov-version:
+          - '2.x'
 
     steps:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,14 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      chrome:
+      chromedriver:
         condition: service_started
     ports:
       - "80:80"
     environment:
       SIMPLETEST_BASE_URL: 'http://drupal'
       SIMPLETEST_DB: 'mysql://database:database@database/database'
-      MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chrome:9515"]'
-      SYMFONY_DEPRECATIONS_HELPER: weak
+      MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", { "chromeOptions": { "w3c": false } }, "http://chromedriver:4444/wd/hub"]'
     volumes:
       - ./html:/var/www/html
 
@@ -36,9 +35,14 @@ services:
       timeout: 5s
       retries: 100
 
-  chrome:
-    image: drupalci/webdriver-chromedriver:production
-    container_name: chrome
+  chromedriver:
+    image: robcherry/docker-chromedriver:latest
+    container_name: chromedriver
+    environment:
+      CHROMEDRIVER_WHITELISTED_IPS: ""
+      CHROMEDRIVER_URL_BASE: "/wd/hub"
+    security_opt:
+      - seccomp:unconfined
     ports:
       - "4444:4444"
       - "9515:9515"
@@ -46,8 +50,4 @@ services:
       core:
         soft: -1
         hard: -1
-    entrypoint:
-      - chromedriver
-      - "--log-path=/tmp/chromedriver.log"
-      - "--verbose"
-      - "--whitelisted-ips="
+    entrypoint: ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]


### PR DESCRIPTION
All JS tests are failing because of issues with Chrome in our Docker Compose test setup.

This replaces the `drupalci/webdriver-chromedriver` with `robcherry/docker-chromedriver`, which we use in Lando.

Also removes tests against LocalGov 1.x

Fixes #17 
Fixes #19 