### PR TITLE
Pin Google Chrome to version 106

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       retries: 100
 
   chromedriver:
-    image: selenium/standalone-chrome:latest
+    image: selenium/standalone-chrome:106.0
     container_name: chromedriver
     environment:
       START_XVBF: 'false'


### PR DESCRIPTION
[SeleniumHQ suggests](https://github.com/SeleniumHQ/docker-selenium#quick-start): "Always use a Docker image with a full tag to pin a specific browser and Grid version." The "latest" tag that we are using at present is currently referring to Chrome and ChromeDriver version 107 which is throwing Java errors.  So sticking to version 106 appears to be a good idea in the *short term*.

Corresponding change for PHP 7.4: #23 