### PR TITLE
Use PHP 8.3 container in testing environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     name: Build and test LocalGov Drupal
     runs-on: ubuntu-latest
-    
-    
+
+
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
       - name: setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - uses: actions/checkout@v2
 
@@ -36,7 +36,7 @@ jobs:
         run: jq --raw-output '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | sort | uniq | xargs composer --working-dir=./html require --dev --no-interaction
 
       - name: Start Docker environment
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Run tests
         run: ./run-tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 services:
 
   drupal:
-    image: localgovdrupal/apache-php:php8.2
+    image: localgovdrupal/apache-php:php8.3
     container_name: drupal
     depends_on:
       database:


### PR DESCRIPTION
## What does this change?

Fixes bug where we were actually testing against PHP 8.2 rather than PHP 8.3 in PHP 8.3 tests.

## How to test

PHP 8.3 tests should run without Composer error about PHP version.
