### PR TITLE
Add multi-architecture (amd64/arm64) container builds with GHCR support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "php8.3"
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "php8.3"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,51 @@
+name: Build and Push Multi-arch Image
+
+on:
+  push:
+    branches:
+      - php*
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build and push multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract base image tag from Dockerfile
+        id: extract-tag
+        run: |
+          # Extract FROM line and convert php:8.3-apache → php8.3-apache
+          BASE_IMAGE=$(grep -m1 '^FROM' Dockerfile | awk '{print $2}')
+          TAG=$(echo "$BASE_IMAGE" | tr ':' '-' | tr '/' '-')
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Extracted tag: $TAG"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ steps.extract-tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - php*
+  merge_group:
+    branches:
+      - php*
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,23 @@ docker-compose stop
 
 ## Building the Docker image
 
-The Docker image lives in [Docker Hub](https://hub.docker.com/repository/docker/localgovdrupal/apache-php). Ask in [Slack](https://localgovdrupal.slack.com/) if you need the permissions to push new images.
+### Automated builds (GHCR)
 
-Build with:
+Multi-architecture images (amd64/arm64) are automatically built and pushed to GitHub Container Registry on every push to `php*` branches:
+
+```
+ghcr.io/<owner>/drupal-container:<php-version>-apache
+```
+
+For example: `ghcr.io/localgovdrupal/drupal-container:php-8.3-apache`
+
+You can also trigger a build manually via the [Actions tab](../../actions/workflows/build-push.yml).
+
+### Manual builds (Docker Hub)
+
+The Docker image also lives in [Docker Hub](https://hub.docker.com/repository/docker/localgovdrupal/apache-php). Ask in [Slack](https://localgovdrupal.slack.com/) if you need the permissions to push new images.
+
+Build and push manually with:
 
 ```bash
 export branch=$(git symbolic-ref --short HEAD)


### PR DESCRIPTION
## Summary

This PR adds automated multi-architecture Docker image builds (linux/amd64 and linux/arm64) with automatic publishing to GitHub Container Registry (GHCR).

### What's included

- **New workflow**: `.github/workflows/build-push.yml` - Builds and pushes multi-arch images on every push to `php*` branches
- **Updated README**: Documents the new automated build process alongside the existing manual Docker Hub workflow

### Benefits

**🚫 No rate limiting**
Unlike Docker Hub, GHCR has no anonymous pull rate limits. This is particularly valuable for CI/CD pipelines where Docker Hub's 100 pulls/6 hours limit can cause build failures during busy periods.

**💰 Cost savings with ARM support**
ARM64 instances (AWS Graviton, Azure Ampere, GCP Tau T2A) are typically 20-40% cheaper than equivalent x86 instances while offering comparable or better performance. Adding arm64 support enables the community to run LocalGov Drupal on these more cost-effective platforms.

**🔄 Dynamic tagging**
The workflow automatically extracts the base image tag from the Dockerfile, so when you update `FROM php:8.4-apache`, it will automatically tag as `php-8.4-apache` - no manual tag updates needed.

**📦 Works for upstream and forks**
Uses `${{ github.repository }}` so the same workflow works in the main repo and any forks without modification.

### Image locations

Once merged, images will be available at:
```
ghcr.io/localgovdrupal/drupal-container:php-8.3-apache
```

### Adding Docker Hub publishing (optional)

If you'd also like to automatically push to Docker Hub alongside GHCR, you can add these steps to the workflow:

```yaml
      - name: Login to Docker Hub
        uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_TOKEN }}
```

And update the `tags` in the build step:
```yaml
          tags: |
            ghcr.io/${{ github.repository }}:${{ steps.extract-tag.outputs.tag }}
            localgovdrupal/apache-php:${{ github.ref_name }}
```

This would require adding `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repository.

---

We've verified the workflow works - our fork's build completed successfully and the multi-arch image is functioning correctly:

```
$ docker buildx imagetools inspect ghcr.io/co-cddo/drupal-container:php-8.3-apache
Manifests: 
  Platform: linux/amd64
  Platform: linux/arm64
```

We're happy to make any changes you'd suggest - please let us know if you have any feedback or would like us to adjust anything.