### PR TITLE
Fix CI tests by installing drupal/group module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Create LocalGov Drupal project
         run: composer create-project --stability dev localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
 
+      - name: Install optional module dependencies for tests
+        run: composer --working-dir=./html require --dev drupal/group
+
       - name: Obtain all dev dependencies for LocalGov Drupal
         run: jq --raw-output '.packages[] | select(.name | startswith("localgovdrupal/")) | ."require-dev" | values | to_entries[] | @sh "\(.key):\(.value)"' ./html/composer.lock | sort | uniq | xargs composer --working-dir=./html require --dev --no-interaction
 


### PR DESCRIPTION
## Summary

This PR fixes the CI test failures that have been occurring since at least December 2024.

### The Problem

The test suite was failing with:
```
Class "Drupal\Tests\group\Kernel\GroupKernelTestBase" not found
```

This occurs because the `localgov_alert_banner` module includes an optional `group_alert_banner` submodule. When PHPUnit/Paratest discovers and loads test files, it attempts to load `GroupAlertBannerTest` which extends `GroupKernelTestBase` from the `drupal/group` module. Without the `group` module installed, this class resolution fails and breaks the entire test run.

### The Fix

Install `drupal/group` as a dev dependency in CI so all test classes can be properly loaded and executed.

## Changes

- Added a step in `.github/workflows/test.yml` to install `drupal/group` via composer before running tests

## Test plan

- [ ] CI workflow completes successfully
- [ ] All test suites run (PHPCS, PHPStan, PHPUnit)
- [ ] `GroupAlertBannerTest` runs and passes